### PR TITLE
fix 'status' exit code

### DIFF
--- a/lib/App/Twitch.pm
+++ b/lib/App/Twitch.pm
@@ -544,7 +544,7 @@ sub run {
 	};
 	if ($cmd eq 'status') {
 		print "Status: ".__PACKAGE__." is ".( $self->status ? '' : 'not ')."running...\n";
-		exit $self->status ? 0 : 1;
+		exit($self->status ? 0 : 1);
 	}
 	if ($cmd eq 'restart') {
 		if ($self->status) {


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $self->status ? 0 : 1` parses as `(exit $self->status) ? 0 : 1`, which is not what was intended.